### PR TITLE
Use items() rather than iteritems(), for Python 3 compatibility

### DIFF
--- a/templates/default.j2
+++ b/templates/default.j2
@@ -2,7 +2,7 @@
 {% if i is string  %}
 {{ i }}
 {% elif i is mapping %}
-{% for k,v in i.iteritems() %}
+{% for k,v in i.items() %}
 {{ k }}={{ v }}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Solves `AnsibleUndefinedVariable: 'dict object' has no attribute 'iteritems'` when running playbooks that use the systemd role, on Python 3.